### PR TITLE
Add possibility to provide custom values

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ Post
 ```
 
 ### Advanced
-You can pass in an object to override the default settings 
+You can pass in an object to override the default settings
 ```javascript
 
 let Model = require('objection').Model
@@ -73,5 +73,36 @@ Post
     .then(john => {
         console.log(john.my_created_at) // my date format
         console.log(john.my_updated_at) // my date format
+    })
+```
+
+If you provide custom values plugin won't override them
+```javascript
+
+let Model = require('objection').Model
+let timestampPlugin = require('objection-timestamps')
+
+class Post extends timestampPlugin(Model) {
+    static get tableName () {
+        return 'user'
+    }
+
+    // allow timestamp plugin on this model
+    static get timestamp () {
+        return true
+    }
+}
+
+Post
+    .query()
+    .insertAndFetch({
+        firstName: 'John',
+        lastName: 'Doe',
+        created_at: 'Foobar',
+        updated_at: 'Foobiz'
+    })
+    .then(john => {
+        console.log(john.created_at) // Foobar
+        console.log(john.updated_at) // Foobiz
     })
 ```

--- a/index.js
+++ b/index.js
@@ -25,8 +25,8 @@ function timeStampModel (opts, Model) {
       if (this.constructor.timestamp) {
         return Promise.resolve(promise)
           .then(() => {
-            this[opts.createdAt] = opts.genDate()
-            this[opts.updatedAt] = opts.genDate()
+            this[opts.createdAt] = this[opts.createdAt] || opts.genDate()
+            this[opts.updatedAt] = this[opts.updatedAt] || opts.genDate()
           })
       }
       return Promise.resolve(promise)
@@ -38,7 +38,7 @@ function timeStampModel (opts, Model) {
       if (this.constructor.timestamp) {
         return Promise.resolve(promise)
           .then(() => {
-            this[opts.updatedAt] = opts.genDate()
+            this[opts.updatedAt] = this[opts.updatedAt] || opts.genDate()
           })
       }
       return Promise.resolve(promise)


### PR DESCRIPTION
This PR adds the possibility to provide custom values to `created_at` and `updated_at` instead of overriding.

Example:

If you provide a `created_at` on an insert, that value will be used and the plugin will not generate a new date for `created_at` field. The same applies to `updated_at`.
